### PR TITLE
Add .travis.yml for continuous integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
 script:
 - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export CMAKE_INCLUDE_PATH='/usr/local/opt/openssl/include'; fi
 - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export CMAKE_LIBRARY_PATH='/usr/local/opt/openssl/lib'; fi
-- cmake .
+- cmake -D DISABLE_ZPNG=1 -D DISABLE_ZJPEG=1 -D DISABLE_ZWEBP=1 .
 - make pok3rtool
 - ./pok3rtool/pok3rtool list | tee -a output
 - test "$(head -n1 output)" == '[00:00:00:000] N List Devices...'

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
 script:
 - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export CMAKE_INCLUDE_PATH='/usr/local/opt/openssl/include'; fi
 - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export CMAKE_LIBRARY_PATH='/usr/local/opt/openssl/lib'; fi
-- cmake -D DISABLE_ZPNG=1 -D DISABLE_ZJPEG=1 -D DISABLE_ZWEBP=1 .
+- cmake -D DISABLE_ZPNG=1 -D DISABLE_ZJPEG=1 -D DISABLE_ZWEBP=1 -D DISABLE_ZDATABASE=1 .
 - make pok3rtool
 - ./pok3rtool/pok3rtool list | tee -a output
 - test "$(head -n1 output)" == '[00:00:00:000] N List Devices...'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: cpp
+
+os:
+- linux
+- osx
+
+compiler:
+- clang
+- gcc
+
+addons:
+  apt:
+    sources:
+    # For CMake 3.x
+    - george-edison55-precise-backports
+    - ubuntu-toolchain-r-test
+    packages:
+    - cmake
+    - cmake-data
+    - libssl-dev
+    - libusb-dev
+    - gcc-4.8
+    - g++-4.8
+    - clang
+
+before_install:
+- uname -a
+- if [ "$CXX" = "g++" -a "$TRAVIS_OS_NAME" == "linux" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+- $CC --version
+- $CXX --version
+- git submodule init
+- git submodule update
+# Disable doxygen and latex. TODO: Add a cmake flag to make documentation optional.
+- sed -i 's/INCLUDE(cmake\/Doxygen.cmake)//g' pok3rtool/libchaos/CMakeLists.txt
+- if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install openssl; fi
+
+script:
+- if [ "$TRAVIS_OS_NAME" == "osx" ]; then export CMAKE_INCLUDE_PATH='/usr/local/opt/openssl/include'; fi
+- if [ "$TRAVIS_OS_NAME" == "osx" ]; then export CMAKE_LIBRARY_PATH='/usr/local/opt/openssl/lib'; fi
+- cmake .
+- make pok3rtool
+- ./pok3rtool/pok3rtool list | tee -a output
+- test "$(head -n1 output)" == '[00:00:00:000] N List Devices...'

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ addons:
     - cmake-data
     - libssl-dev
     - libusb-dev
-    - gcc-4.8
-    - g++-4.8
+    - gcc-4.9
+    - g++-4.9
     - clang
 
 before_install:
 - uname -a
-- if [ "$CXX" = "g++" -a "$TRAVIS_OS_NAME" == "linux" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+- if [ "$CXX" = "g++" -a "$TRAVIS_OS_NAME" == "linux" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
 - $CC --version
 - $CXX --version
 - git submodule init

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ before_install:
 - git submodule init
 - git submodule update
 # Disable doxygen and latex. TODO: Add a cmake flag to make documentation optional.
-- sed -i 's/INCLUDE(cmake\/Doxygen.cmake)//g' pok3rtool/libchaos/CMakeLists.txt
+- if [ "$TRAVIS_OS_NAME" == "osx" ]; then sed -i '' 's/INCLUDE(cmake\/Doxygen.cmake)//g' pok3rtool/libchaos/CMakeLists.txt; fi
+- if [ "$TRAVIS_OS_NAME" == "linux" ]; then sed -i 's/INCLUDE(cmake\/Doxygen.cmake)//g' pok3rtool/libchaos/CMakeLists.txt; fi
 - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install openssl; fi
 
 script:


### PR DESCRIPTION
As discussed in #5, this PR is for adding a basic travis config file.

A couple of things to note:
1. All builds are still [broken](https://travis-ci.org/sonph-forks/pok3r_re_firmware/builds/213301384). For the two linux builds with gcc and clang, I'll leave it to you as I have no idea how to fix those. For the two mac builds, the master head commit `e149675` seems to be breaking the build. Reverting it fixes the problem.
2. I'm removing `Doxygen.cmake` out of `libchaos/CMakeLists.txt` as it requires latex as a temporary workaround. I tried installing mactex via brew, but the build always times out. Ideally we should have someway to disable building documentation?
3. Not sure if I'm exporting `CMAKE_INCLUDE_PATH` and `CMAKE_LIBRARY_PATH` for macOS the right way but it works. If that's wrong I'll fix it.